### PR TITLE
added tests and methods in SalesAnalyst for avg. item/merchant & std_dev

### DIFF
--- a/DTR_29FEB2016.md
+++ b/DTR_29FEB2016.md
@@ -75,3 +75,4 @@ Ling:
 * Be direct with Ling, please. She can handle it.
 
 ###### 10. Additional Notes:
+Link to Waffle.io: [https://waffle.io/drew-t/black_thursday]

--- a/lib/sales_analyst.rb
+++ b/lib/sales_analyst.rb
@@ -1,0 +1,30 @@
+require_relative 'sales_engine'
+require 'csv'
+require 'pry'
+
+class SalesAnalyst
+  def initialize(se)
+    @se = se
+  end
+
+  def average_items_per_merchant
+    (@se.items.repository.count.to_f/@se.merchants.repository.count.to_f).round(2)
+  end
+
+  def items_per_merchant_hash
+    @se.items.repository.group_by { |item| item.merchant_id }
+  end
+
+  def item_count_per_merchant_hash
+    items_per_merchant_hash.map {|merchant_id, items| [merchant_id, items.count] }.to_h
+  end
+
+  def average_items_per_merchant_standard_deviation
+    n = item_count_per_merchant_hash.values.map do |value|
+      (value - average_items_per_merchant)**2
+    end.reduce(:+)/(@se.merchants.repository.count.to_f - 1)
+    
+    Math.sqrt(n).round(2)
+  end
+
+end

--- a/lib/sales_analyst.rb
+++ b/lib/sales_analyst.rb
@@ -8,23 +8,36 @@ class SalesAnalyst
   end
 
   def average_items_per_merchant
-    (@se.items.repository.count.to_f/@se.merchants.repository.count.to_f).round(2)
+    @average_items_per_merchant = (@se.items.repository.count.to_f/@se.merchants.repository.count.to_f).round(2)
   end
 
-  def items_per_merchant_hash
+  def items_per_merchant_hash #need test?
     @se.items.repository.group_by { |item| item.merchant_id }
   end
 
-  def item_count_per_merchant_hash
-    items_per_merchant_hash.map {|merchant_id, items| [merchant_id, items.count] }.to_h
+  def item_count_per_merchant_hash # need test?
+    items_per_merchant_hash.map { |merchant_id, items| [merchant_id, items.count] }.to_h
   end
 
   def average_items_per_merchant_standard_deviation
     n = item_count_per_merchant_hash.values.map do |value|
-      (value - average_items_per_merchant)**2
-    end.reduce(:+)/(@se.merchants.repository.count.to_f - 1)
-    
-    Math.sqrt(n).round(2)
+          (value - average_items_per_merchant)**2
+        end.reduce(:+)/(@se.merchants.repository.count.to_f - 1)
+
+    @std_dev = Math.sqrt(n).round(2)
+  end
+
+  def merchants_with_high_item_count # >= 1 std_dev or > 1 std_dev?
+    # display as an array merchants who have the most items for sale
+    # eligibility determined by std_dev > 1 above the average number of products offered; so want merchants with items numbering >= 9.40 = 3.26 (2 std_dev)+ 2.88(avg. items per merchant)
+    # more than 1 std_dev meaning > 6.14
+    one_std_dev = @std_dev + @average_items_per_merchant
+
+    merchants_with_high_item_count = item_count_per_merchant_hash.find_all do |merchant_id, item_count|
+                                        merchant_id if item_count > one_std_dev
+                                      end.map do |element|
+                                        @se.merchants.find_by_id(element[0])
+                                      end
   end
 
 end

--- a/lib/sales_analyst.rb
+++ b/lib/sales_analyst.rb
@@ -1,6 +1,7 @@
-require_relative 'sales_engine'
+require_relative '../lib/sales_engine'
 require 'csv'
 require 'pry'
+require 'bigdecimal'
 
 class SalesAnalyst
   def initialize(se)
@@ -35,15 +36,25 @@ class SalesAnalyst
     ((average_items_per_merchant_standard_deviation * 2) + average_items_per_merchant).round(2)
   end
 
-  def merchants_with_high_item_count # >= 1 std_dev or > 1 std_dev?
-    # display as an array merchants who have the most items for sale
-    # eligibility determined by std_dev > 1 above the average number of products offered; so want merchants with items numbering >= 9.40 = 3.26 (2 std_dev)+ 2.88(avg. items per merchant)
-    # more than 1 std_dev meaning > 6.14
-    merchants_with_high_item_count = item_count_per_merchant_hash.find_all do |merchant_id, item_count|
-                                        merchant_id if item_count > one_std_dev
-                                      end.map do |element|
-                                        @se.merchants.find_by_id(element[0])
-                                      end
+  def merchants_with_high_item_count
+    item_count_per_merchant_hash.find_all do |merchant_id, item_count|
+        merchant_id if item_count > one_std_dev
+      end.map do |element|
+        @se.merchants.find_by_id(element[0])
+      end
   end
 
+  def average_item_price_for_merchant(merchant_id)
+    x = items_per_merchant_hash
+    n = BigDecimal.new(x[merchant_id].reduce(0) do |sum, item|
+      sum += item.unit_price.to_i
+    end/x.count)
+  end
+
+  def average_average_price_per_merchant
+    x = items_per_merchant_hash
+    BigDecimal.new(x.map do |merchant, items|
+      average_item_price_for_merchant(merchant)
+    end.reduce(:+)/x.count)
+  end
 end

--- a/lib/sales_analyst.rb
+++ b/lib/sales_analyst.rb
@@ -8,7 +8,7 @@ class SalesAnalyst
   end
 
   def average_items_per_merchant
-    @average_items_per_merchant = (@se.items.repository.count.to_f/@se.merchants.repository.count.to_f).round(2)
+     (@se.items.repository.count.to_f/@se.merchants.repository.count.to_f).round(2)
   end
 
   def items_per_merchant_hash #need test?
@@ -24,15 +24,21 @@ class SalesAnalyst
           (value - average_items_per_merchant)**2
         end.reduce(:+)/(@se.merchants.repository.count.to_f - 1)
 
-    @std_dev = Math.sqrt(n).round(2)
+    Math.sqrt(n).round(2)
+  end
+
+  def one_std_dev
+    average_items_per_merchant_standard_deviation + average_items_per_merchant
+  end
+
+  def two_std_dev
+    ((average_items_per_merchant_standard_deviation * 2) + average_items_per_merchant).round(2)
   end
 
   def merchants_with_high_item_count # >= 1 std_dev or > 1 std_dev?
     # display as an array merchants who have the most items for sale
     # eligibility determined by std_dev > 1 above the average number of products offered; so want merchants with items numbering >= 9.40 = 3.26 (2 std_dev)+ 2.88(avg. items per merchant)
     # more than 1 std_dev meaning > 6.14
-    one_std_dev = @std_dev + @average_items_per_merchant
-
     merchants_with_high_item_count = item_count_per_merchant_hash.find_all do |merchant_id, item_count|
                                         merchant_id if item_count > one_std_dev
                                       end.map do |element|

--- a/test/sales_analyst_integration_test.rb
+++ b/test/sales_analyst_integration_test.rb
@@ -36,6 +36,24 @@ class SalesAnalystTest < Minitest::Test
     assert_equal 3.26, sa.average_items_per_merchant_standard_deviation
   end
 
+  def test_can_calculate_number_for_one_std_dev
+    se = SalesEngine.from_csv({
+      :items     => "../data/items.csv",
+      :merchants => "../data/merchants.csv",
+    })
+    sa = SalesAnalyst.new(se)
+    assert_equal 6.14, sa.one_std_dev
+  end
+
+  def test_can_calculate_number_for_two_std_dev
+    se = SalesEngine.from_csv({
+      :items     => "../data/items.csv",
+      :merchants => "../data/merchants.csv",
+    })
+    sa = SalesAnalyst.new(se)
+    assert_equal 9.40, sa.two_std_dev
+  end
+
   def test_can_calculate_merchants_more_than_one_std_dev_from_avg_number_of_products_offered
     se = SalesEngine.from_csv({
       :items     => "../data/items.csv",

--- a/test/sales_analyst_integration_test.rb
+++ b/test/sales_analyst_integration_test.rb
@@ -1,0 +1,39 @@
+require 'pry'
+require 'minitest/autorun'
+require 'minitest/pride'
+require '../lib/merchant'
+require '../lib/merchant_repository'
+require '../lib/item'
+require '../lib/item_repository'
+require '../lib/sales_engine'
+require '../lib/sales_analyst'
+
+class SalesAnalystTest < Minitest::Test
+  def test_sales_analyst_can_be_instantiated_with_sales_engine
+    se = SalesEngine.from_csv({
+      :items     => "../data/items.csv",
+      :merchants => "../data/merchants.csv",
+    })
+    sa = SalesAnalyst.new(se)
+
+    assert sa
+  end
+
+  def test_sales_analyst_can_calculate_average_items_per_merchant
+    se = SalesEngine.from_csv({
+      :items     => "../data/items.csv",
+      :merchants => "../data/merchants.csv",
+    })
+    sa = SalesAnalyst.new(se)
+    assert_equal 2.88, sa.average_items_per_merchant
+  end
+
+  def test_sales_analyst_can_calculate_average_items_per_merchant_standard_deviation
+    se = SalesEngine.from_csv({
+      :items     => "../data/items.csv",
+      :merchants => "../data/merchants.csv",
+    })
+    sa = SalesAnalyst.new(se)
+    assert_equal 3.26, sa.average_items_per_merchant_standard_deviation
+  end
+end

--- a/test/sales_analyst_integration_test.rb
+++ b/test/sales_analyst_integration_test.rb
@@ -1,12 +1,12 @@
 require 'pry'
 require 'minitest/autorun'
 require 'minitest/pride'
-require '../lib/merchant'
-require '../lib/merchant_repository'
-require '../lib/item'
-require '../lib/item_repository'
-require '../lib/sales_engine'
-require '../lib/sales_analyst'
+require_relative '../lib/merchant'
+require_relative '../lib/merchant_repository'
+require_relative '../lib/item'
+require_relative '../lib/item_repository'
+require_relative '../lib/sales_engine'
+require_relative '../lib/sales_analyst'
 
 class SalesAnalystTest < Minitest::Test
   def test_sales_analyst_can_be_instantiated_with_sales_engine
@@ -61,5 +61,26 @@ class SalesAnalystTest < Minitest::Test
     })
     sa = SalesAnalyst.new(se)
     assert_equal 52, sa.merchants_with_high_item_count.count
+  end
+
+  def test_can_calculate_average_item_price_for_specific_merchant_id_for_merchants_with_high_item_count
+    se = SalesEngine.from_csv({
+      :items     => "../data/items.csv",
+      :merchants => "../data/merchants.csv",
+    })
+    sa = SalesAnalyst.new(se)
+    assert_equal BigDecimal, sa.average_item_price_for_merchant("12334105").class
+    assert_equal 10.00, sa.average_item_price_for_merchant("12334105").to_f.round(2)
+  end
+
+  def test_can_calculate_sum_of_all_the_averages_to_find_average_price_across_all_merchants
+    se = SalesEngine.from_csv({
+      :items     => "../data/items.csv",
+      :merchants => "../data/merchants.csv",
+    })
+    sa = SalesAnalyst.new(se)
+
+    assert_equal BigDecimal, sa.average_average_price_per_merchant.class
+    assert_equal 151.65, sa.average_average_price_per_merchant.to_f.round(2)
   end
 end

--- a/test/sales_analyst_integration_test.rb
+++ b/test/sales_analyst_integration_test.rb
@@ -15,11 +15,10 @@ class SalesAnalystTest < Minitest::Test
       :merchants => "../data/merchants.csv",
     })
     sa = SalesAnalyst.new(se)
-
     assert sa
   end
 
-  def test_sales_analyst_can_calculate_average_items_per_merchant
+  def test_can_calculate_average_items_per_merchant
     se = SalesEngine.from_csv({
       :items     => "../data/items.csv",
       :merchants => "../data/merchants.csv",
@@ -28,12 +27,21 @@ class SalesAnalystTest < Minitest::Test
     assert_equal 2.88, sa.average_items_per_merchant
   end
 
-  def test_sales_analyst_can_calculate_average_items_per_merchant_standard_deviation
+  def test_can_calculate_average_items_per_merchant_standard_deviation
     se = SalesEngine.from_csv({
       :items     => "../data/items.csv",
       :merchants => "../data/merchants.csv",
     })
     sa = SalesAnalyst.new(se)
     assert_equal 3.26, sa.average_items_per_merchant_standard_deviation
+  end
+
+  def test_can_calculate_merchants_more_than_one_std_dev_from_avg_number_of_products_offered
+    se = SalesEngine.from_csv({
+      :items     => "../data/items.csv",
+      :merchants => "../data/merchants.csv",
+    })
+    sa = SalesAnalyst.new(se)
+    assert_equal 52, sa.merchants_with_high_item_count.count
   end
 end


### PR DESCRIPTION
Added tests and methods in SalesAnalyst to calculate average items per merchant and standard deviation. No glaring issue at the moment in pulling from item and merchant repositories in terms of data integrity.